### PR TITLE
Also set "+ visual mode keybinding when +clipboard is not supported

### DIFF
--- a/plugin/wayland_clipboard.vim
+++ b/plugin/wayland_clipboard.vim
@@ -45,4 +45,5 @@ nnoremap "+P :<C-U>let @"=substitute(system('wl-paste --no-newline'), '<C-v><C-m
 " remap '"+' to '"w' -- see the comment above the declaration of 's:plus_to_w'
 if s:plus_to_w
     nnoremap "+ "w
+    vnoremap "+ "w
 endif


### PR DESCRIPTION
This fixes the copying of selected text after making a selection in
visual mode (eg. `Shift+v` or `Ctrl+v`) on vim builds compiled without
`clipboard` support.