### PR TITLE
Add WaylandYank command; make paste work in visual mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Use Vim8's built-in packages:
 Just use `"+y`, `"+p`, `<C-R>+`, and friends as you always do. Specifically, here's what's supported:
 
 - Any yank command that starts with `"+` (e.g. `"+yy` or `"+yiw`) in insert and visual modes.
-- Pasting in normal mode with `"+p` or `"+P`.
+- Pasting in normal and visual modes with `"+p` or `"+P`.
 - Pasting in insert mode with `<C-R>+`, `<C-R><C-R>+`, `<C-R><C-O>+`, or `<C-R><C-P>+`.
-- Yanking and pasting (`p` and `P` in normal mode) with `clipboard=unnamedplus`.
+- Yanking and pasting (`p` and `P` in normal and visual modes) with `clipboard=unnamedplus`.
 
 If you need more functionality, consider checking out [vim-fakeclip](https://github.com/kana/vim-fakeclip).
 

--- a/plugin/wayland_clipboard.vim
+++ b/plugin/wayland_clipboard.vim
@@ -91,6 +91,11 @@ nnoremap <expr> <silent> "+P <SID>put('P', v:false)
 nnoremap <expr> <silent> p <SID>put('p', &clipboard != 'unnamedplus')
 nnoremap <expr> <silent> P <SID>put('P', &clipboard != 'unnamedplus')
 
+vnoremap <expr> <silent> "+p <SID>put('p', v:false)
+vnoremap <expr> <silent> "+P <SID>put('P', v:false)
+vnoremap <expr> <silent> p <SID>put('p', &clipboard != 'unnamedplus')
+vnoremap <expr> <silent> P <SID>put('P', &clipboard != 'unnamedplus')
+
 inoremap <expr> <silent> <C-R>+ <SID>ctrl_r("\<C-R>")
 inoremap <expr> <silent> <C-R><C-R>+ <SID>ctrl_r("\<C-R>\<C-R>")
 inoremap <expr> <silent> <C-R><C-O>+ <SID>ctrl_r("\<C-R>\<C-O>")


### PR DESCRIPTION
I've added `WaylandYank` command so it can be used in other scripts and mappings. For example:
```vim
" Yank current buffer's filename.
nnoremap <silent> yp :let @+ = expand('%:t') \| WaylandYank +<CR>
```
Another change is that paste mappings will also work in visual mode now.