### PR TITLE
Enable w reg clobbering if xwayland isn't available (no $DISPLAY)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To pass extra arguments to `wl-paste`, use `g:wayland_clipboard_paste_args` in t
 
 ### Clobbering the `w` Register
 
-On Vim builds without `clipboard`, the `+` register doesn't work for yanking. My solution is to map `"+` to `"w` and send the `w` register to the Wayland clipboard as well. (This only occurs when the `clipboard` feature is missing.) If you use the `w` register for other things and don't want it to clobber your system clipboard, put `let g:wayland_clipboard_no_plus_to_w = 1` in your `vimrc` to disable this feature.
+On Vim builds without `clipboard`, or if Xwayland isn't running, the `+` register doesn't work for yanking. My solution is to map `"+` to `"w` and send the `w` register to the Wayland clipboard as well. (This only occurs when the `clipboard` feature is missing or the X `$DISPLAY` environment vairable is empty.) If you use the `w` register for other things and don't want it to clobber your system clipboard, put `let g:wayland_clipboard_no_plus_to_w = 1` in your `vimrc` to disable this feature.
 
 ### Non-recursive Mappings
 

--- a/plugin/wayland_clipboard.vim
+++ b/plugin/wayland_clipboard.vim
@@ -23,14 +23,18 @@ endif
 
 " Yanking {{{
 
-" On Vim builds without 'clipboard', the '+' register doesn't work for
-" yanking. My solution is to map '"+' to '"w' and send the 'w' register to the
+" The '+' register doesn't work for yanking if:
+" - vim was built without 'clipboard'.
+" - x11 / xwayland is unavailable.
+" (https://github.com/vim/vim/blob/93197fde0f1db09b1e495cf3eb14a8f42c318b80/src/register.c#L247)
+"
+" My solution is to map '"+' to '"w' and send the 'w' register to the
 " Wayland clipboard as well.
 "
 " This variable controls whether '"+' gets mapped to '"w'. It's on by default
-" if the 'clipboard' feature isn't available, but the user can turn it off
-" always if desired.
-let s:plus_to_w = !has('clipboard') && !exists('g:wayland_clipboard_no_plus_to_w')
+" if the 'clipboard' feature isn't available, or if $DISPLAY isn't set,
+" but the user can turn it off always if desired.
+let s:plus_to_w = (!has('clipboard') || empty($DISPLAY)) && !exists('g:wayland_clipboard_no_plus_to_w')
 
 " remap '"+' to '"w' -- this will only apply to yanking since '"+p' and '"+P'
 " are also remapped below


### PR DESCRIPTION
The + register in vim isn't available if it isn't built with the `clipboard` feature. We work around this by detecting it, and remapping the + register to w.

But the + register can also be unavailable if vim is unable to connect to an X server.

Try to detect the lack of X server by checking the $DISPLAY environment variable (which X applications use to connect to the right X server, but isn't used by wayland), and also use the w register in that case.