### PR TITLE
Allow copying big text by using stdin for wl-copy

### DIFF
--- a/plugin/wayland_clipboard.vim
+++ b/plugin/wayland_clipboard.vim
@@ -55,10 +55,11 @@ function! s:WaylandYank()
     if v:event['regname'] == '+' ||
                 \ (v:event['regname'] == 'w' && s:plus_to_w) ||
                 \ (v:event['regname'] == '' && s:unnamedplus())
-        silent call job_start(['wl-copy'] + s:copy_args + ['--', getreg(v:event['regname'])], {
-            \   "in_io": "null", "out_io": "null", "err_io": "null",
+        let job = job_start(['wl-copy'] + s:copy_args, {
+            \   "in_io": "pipe", "out_io": "null", "err_io": "null",
             \   "stoponexit": "",
             \ })
+        call ch_sendraw(job, getreg(v:event['regname']))
     endif
 endfunction
 


### PR DESCRIPTION
Passing large text as an argument to wl-copy can exceed a certain limit. This change modifies wl-copy to read from stdin through a pipe, allowing for larger inputs to be copied successfully.

On my environment, the limit was 131071 bytes.