### PR TITLE
Made the clipboard management backend configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,34 @@ let g:wayland_clipboard_copy_args = ['--primary', '--paste-once']
 
 To pass extra arguments to `wl-paste`, use `g:wayland_clipboard_paste_args` in the same way.
 
+### Using a different clipboard backend
+
+If you want a different backend to manage your clipboard operations, there are the `g:wayland_clipboard_copy_command`
+and `g:wayland_clipboard_paste_command` variables, which can be used together with the aforementioned
+`g:wayland_clipboard_copy_args` and `g:wayland_clipboard_paste_args`.
+
+As an example, a *KDE Plasma 6* user might want to integrate the Klipper D-Bus service, usually loaded
+at the startup by the desktop environment itself:
+
+```vimscript
+let g:wayland_clipboard_copy_command = 'qdbus6'
+let g:wayland_clipboard_paste_command = 'qdbus6'
+
+let g:wayland_clipboard_copy_args = ['org.kde.klipper', '/klipper', 'setClipboardContents']
+let g:wayland_clipboard_paste_args = ['org.kde.klipper', '/klipper', 'getClipboardContents']
+```
+
+Of course, this would work the same under *KDE Plasma 5*, just replace *qdbus6* with *qdbus*,
+the arguments can stay the same:
+
+```vimscript
+let g:wayland_clipboard_copy_command = 'qdbus'
+let g:wayland_clipboard_paste_command = 'qdbus'
+
+let g:wayland_clipboard_copy_args = ['org.kde.klipper', '/klipper', 'setClipboardContents']
+let g:wayland_clipboard_paste_args = ['org.kde.klipper', '/klipper', 'getClipboardContents']
+```
+
 ### Clobbering the `w` Register
 
 On Vim builds without `clipboard`, or if Xwayland isn't running, the `+` register doesn't work for yanking. My solution is to map `"+` to `"w` and send the `w` register to the Wayland clipboard as well. (This only occurs when the `clipboard` feature is missing or the X `$DISPLAY` environment vairable is empty.) If you use the `w` register for other things and don't want it to clobber your system clipboard, put `let g:wayland_clipboard_no_plus_to_w = 1` in your `vimrc` to disable this feature.

--- a/plugin/wayland_clipboard.vim
+++ b/plugin/wayland_clipboard.vim
@@ -43,6 +43,7 @@ if s:plus_to_w
     vnoremap "+ "w
 endif
 
+let s:copy_command = exists('g:wayland_clipboard_copy_command') ? g:wayland_clipboard_copy_command : 'wl-copy'
 let s:copy_args = exists('g:wayland_clipboard_copy_args') ? g:wayland_clipboard_copy_args : []
 
 function! s:unnamedplus()
@@ -55,7 +56,7 @@ function! s:WaylandYank()
     if v:event['regname'] == '+' ||
                 \ (v:event['regname'] == 'w' && s:plus_to_w) ||
                 \ (v:event['regname'] == '' && s:unnamedplus())
-        let job = job_start(['wl-copy'] + s:copy_args, {
+        let job = job_start([s:copy_command] + s:copy_args, {
             \   "in_io": "pipe", "out_io": "null", "err_io": "null",
             \   "stoponexit": "",
             \ })
@@ -76,11 +77,12 @@ augroup END
 
 " remap paste commands to first pull in clipboard contents with wl-paste
 
+let s:paste_command = exists('g:wayland_clipboard_paste_command') ? g:wayland_clipboard_paste_command : 'wl-paste --no-newline'
 let s:paste_args = exists('g:wayland_clipboard_paste_args') ? g:wayland_clipboard_paste_args : []
 let s:paste_args_str = empty(s:paste_args) ? '' : ' ' . join(s:paste_args)
 
 function! s:clipboard_to_unnamed()
-    silent let @"=substitute(system('wl-paste --no-newline' . s:paste_args_str), "\r", '', 'g')
+    silent let @"=substitute(system(s:paste_command . s:paste_args_str), "\r", '', 'g')
 endfunction
 
 function! s:put(p, fallback)


### PR DESCRIPTION
I wanted another service to manage the copy and paste actions, so I made some slight changes to allow configurable tools to do the job.

For that purpose, I introduced the global variables *g:vim_clipboard_copy_command* and *g:vim_clipboard_paste_command*.

When these two variables are not set up, they both default to the previous *wl-copy* and *wl-paste* commands.

Thanks for this plugin!